### PR TITLE
Fixed the issue of stylesheet not loading

### DIFF
--- a/source.php
+++ b/source.php
@@ -1135,7 +1135,7 @@ function rtsocial_assets() {
     }
 
     //Plugin CSS
-    wp_enqueue_style( 'styleSheet', plugins_url( 'styles/style.css', __FILE__ ) );
+    wp_enqueue_style( 'rtsocial-styleSheet', plugins_url( 'styles/style.css', __FILE__ ) );
     //Plugin JS
     wp_enqueue_script( 'rtss-main', plugins_url( '/js/rtss-main.js', __FILE__ ), array( 'jquery' ), '1.0', true );
     //Localize Script


### PR DESCRIPTION
The problem with the code is,

> stylesheet doesn't load if other activated plugins had a handler named "stylesheet" when enqueueing stylesheets. 

`prefixing the plugin name when enqueuing the stylesheet solves the issue.`
 