### PR TITLE
update jq method live with on

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,7 @@ No. Right now you cannot.
 * Bug fix for google plus counter
 * Bug fix for stylesheet not loading if other plugins uses the same stylesheet handler
 * Fixed - Plugin settings used to get deleted upon plugin deactivation
+
+## Does this interest you?
+
+<a href="https://rtcamp.com/"><img src="https://rtcamp.com/wp-content/uploads/2019/04/github-banner@2x.png" alt="Join us at rtCamp, we specialize in providing high performance enterprise WordPress solutions"></a>

--- a/js/rtss-main.js
+++ b/js/rtss-main.js
@@ -277,7 +277,7 @@ jQuery( '#fb_chk' ).click( function() {
     }
 } );
 
-jQuery( '.fb_color' ).live( 'click', function() {
+jQuery( '.fb_color' ).on( 'click', function() {
     if ( jQuery( this ).attr( 'value' ) == 'light' ) {
         jQuery( '#fb_like' ).attr( 'src', args.path + 'fb_like.gif' );
         jQuery( '#fb_recommend' ).attr( 'src', args.path + 'fb_recommend.gif' );


### PR DESCRIPTION
This Pr fixed #54  

the jq `live` method got removed in 1.9 and `on` method is used in palce of that.
