### PR TITLE
Remove Google + option from the supported channels section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ With just 1 image (CSS-sprite), 1 JavaScript and 1 CSS file loaded from WordPres
 #### Supported Social Channels ####
 * Facebook
 * Twitter
-* Google+
 * LinkedIn
 * Pinterest
 


### PR DESCRIPTION
Ref: Slack Archive [link](https://rtcamp.slack.com/archives/CQT8TKCJW/p1607941544311200?thread_ts=1607940865.310400&cid=CQT8TKCJW)