### PR TITLE
Add setting to fetch URL share count

### DIFF
--- a/js/rtss-main.js
+++ b/js/rtss-main.js
@@ -14,30 +14,28 @@ function rtsocial_facebook() {
 	if ( '1' === args.facebook && 'icon' !== args.button_style && '1' !== args.hide_count ) {
 		var rtsocial_urls = { }; // create an associative array of url as key and counts.
 		var sep           = '"'; // URL separatore initial value.
-		var tempFbUrl     = ""; // temp variable for url.
+		var tempPostId    = ""; // temp variable for post ID.
 
 		jQuery( '.rtsocial-container' ).each(
 			function () {
 				var facebookSocial     = this;
 				var rtsocial_url_count = 0;
-				tempFbUrl              = jQuery( this ).find( 'a.perma-link' ).attr( 'href' );
-				if ( tempFbUrl !== '' || tempFbUrl !== 'undefined' ) {
-
-					// Fetch share count by Facebook Graph API.
-					var rtsocial_fburl = 'https://graph.facebook.com/?id=' + tempFbUrl + '&fields=og_object{engagement}';
-
-					/**
-					 * Facebook Data.
-					 */
-					jQuery.getJSON(
-						rtsocial_fburl,
-						function ( fbres ) {
-							if ( typeof fbres.og_object !== 'undefined' && fbres.og_object.engagement.count ) {
-								rtsocial_url_count = fbres.og_object.engagement.count; // Setting value.
-							}
-							jQuery( facebookSocial ).find( '.rtsocial-fb-count' ).text( rtsocial_url_count );
+				tempPostId             = jQuery( this ).find( '.rts_id' ).val();
+				security               = jQuery( this ).find( '#rts_media_nonce' ).val();
+				if ( tempPostId !== '' || tempPostId !== 'undefined' ) {
+					jQuery.ajax({
+						type: 'GET',
+						url: ajaxurl,
+						data: {
+							"action"  : "rtss_wp_get_shares",
+							"post_id" : tempPostId,
+							"security": security
+						},
+						success: function(data){
+							jQuery( facebookSocial ).find( '.rtsocial-fb-count' ).text( data );
 						}
-					); /* End of Callback function in JSON. */
+					});
+					return false;
 				}
 			}
 		);

--- a/source.php
+++ b/source.php
@@ -1294,17 +1294,16 @@ function rtsocial_save_meta_box_data( $post_id ) {
 
 /**
  * Display number of shares using WordPress HTTP API
- *
  */
 function rtss_wp_get_shares() {
-	if ( isset( $_GET['security'] ) ) { // WPCS: CSRF ok.
-		$security = wp_unslash( sanitize_text_field( $_GET['security'] ) );
+	if ( isset( $_GET['security'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$security = wp_unslash( $_GET['security'] );
 	} else {
 		$security = '';
 	}
 
 	if ( isset( $_GET['post_id'] ) ) {
-		$post_id = wp_unslash ( sanitize_text_field( $_GET['post_id'] ) );
+		$post_id = wp_unslash ( $_GET['post_id'] );
 	} else {
 		$post_id = '';
 	}

--- a/source.php
+++ b/source.php
@@ -927,6 +927,7 @@ function rtsocial_set_defaults() {
 				'alignment_options_set' => 'right',
 				'active'                => array( 'tw', 'fb', 'lin', 'pin' ),
 				'inactive'              => array(),
+				'fb_access_token'     	=> '',
 			);
 
 			if ( ! get_option( 'rtsocial_plugin_options' ) ) {
@@ -945,6 +946,7 @@ function rtsocial_set_defaults() {
 			'alignment_options_set' => 'right',
 			'active'                => array( 'tw', 'fb', 'lin', 'pin' ),
 			'inactive'              => array(),
+			'fb_access_token'     	=> '',
 		);
 
 		if ( ! get_option( 'rtsocial_plugin_options' ) ) {
@@ -1289,3 +1291,43 @@ function rtsocial_save_meta_box_data( $post_id ) {
 	// Update the meta field in the database.
 	update_post_meta( $post_id, '_rtsocial_visibility', $my_data );
 }
+
+/**
+ * Display number of shares using WordPress HTTP API
+ *
+ * @param integer $post_id We want to get number of shares of the post with this ID
+ */
+function rtss_wp_get_shares() {
+	$security = $_GET[ 'security' ];
+	$post_id  = $_GET[ 'post_id' ];
+	check_ajax_referer( 'rts_media_' . $post_id, 'security' );
+
+	$options = get_option( 'rtsocial_plugin_options' );
+
+	$cache_key = 'rtss_fb' . $post_id;
+	$access_token = $options['fb_access_token'];
+	$count = get_transient( $cache_key ); // try to get value from WordPress cache
+
+	if (  ! $access_token ) {
+		$count = false;
+	}
+
+	// if no value in the cache
+	if ( false === $count || 0 === count ) {
+		$response = wp_remote_get( add_query_arg( array(
+			'id' => urlencode( get_permalink( $post_id ) ),
+			'access_token' => $access_token,
+			'fields' => 'engagement'
+		), 'https://graph.facebook.com/v3.0/' ) );
+		$body = json_decode( $response['body'] );
+
+		$count = intval( $body->engagement->share_count );
+
+		set_transient( $cache_key, $count, 3600 ); // store value in cache for a 1 hour
+	}
+	echo $count;
+	exit;
+}
+
+add_action( 'wp_ajax_rtss_wp_get_shares', 'rtss_wp_get_shares' );
+add_action( 'wp_ajax_nopriv_rtss_wp_get_shares', 'rtss_wp_get_shares' );

--- a/source.php
+++ b/source.php
@@ -1297,13 +1297,13 @@ function rtsocial_save_meta_box_data( $post_id ) {
  */
 function rtss_wp_get_shares() {
 	if ( isset( $_GET['security'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$security = wp_unslash( $_GET['security'] );
+		$security = sanitize_text_field( wp_unslash( $_GET['security'] ) );
 	} else {
 		$security = '';
 	}
 
 	if ( isset( $_GET['post_id'] ) ) {
-		$post_id = wp_unslash ( $_GET['post_id'] );
+		$post_id = sanitize_text_field( wp_unslash( $_GET['post_id'] ) );
 	} else {
 		$post_id = '';
 	}

--- a/source.php
+++ b/source.php
@@ -1332,7 +1332,7 @@ function rtss_wp_get_shares() {
 			)
 		);
 		$body     = json_decode( $response['body'] );
-		if( isset( $body->engagement ) && isset(  $body->engagement->share_count ) ) {
+		if ( isset( $body->engagement ) && isset(  $body->engagement->share_count ) ) {
 			$count = $body->engagement->share_count;
 			set_transient( $cache_key, $count, 3600 ); // store value in cache for a 1 hour.
 		}

--- a/source.php
+++ b/source.php
@@ -1332,7 +1332,7 @@ function rtss_wp_get_shares() {
 			)
 		);
 		$body     = json_decode( $response['body'] );
-		if ( isset( $body->engagement ) && isset(  $body->engagement->share_count ) ) {
+		if ( isset( $body->engagement ) && isset( $body->engagement->share_count ) ) {
 			$count = $body->engagement->share_count;
 			set_transient( $cache_key, $count, 3600 ); // store value in cache for a 1 hour.
 		}

--- a/source.php
+++ b/source.php
@@ -1312,7 +1312,7 @@ function rtss_wp_get_shares() {
 
 	$options      = get_option( 'rtsocial_plugin_options' );
 	$cache_key    = 'rtss_fb' . $post_id;
-	$access_token = $options['fb_access_token'];
+	$access_token = isset( $options['fb_access_token'] ) ? $options['fb_access_token'] : '';
 	$count        = get_transient( $cache_key ); // try to get value from WordPress cache.
 
 	if ( ! $access_token ) {
@@ -1320,7 +1320,7 @@ function rtss_wp_get_shares() {
 	}
 
 	// if no value in the cache.
-	if ( false === $count || 0 === count ) {
+	if ( false === $count || 0 === $count ) {
 		$response = wp_remote_get(
 			add_query_arg(
 				array(
@@ -1332,9 +1332,10 @@ function rtss_wp_get_shares() {
 			)
 		);
 		$body     = json_decode( $response['body'] );
-		$count    = intval( $body->engagement->share_count );
-
-		set_transient( $cache_key, $count, 3600 ); // store value in cache for a 1 hour.
+		if( isset( $body->engagement ) && isset(  $body->engagement->share_count ) ) {
+			$count = $body->engagement->share_count;
+			set_transient( $cache_key, $count, 3600 ); // store value in cache for a 1 hour.
+		}
 	}
 	echo esc_html( $count );
 	exit;

--- a/source.php
+++ b/source.php
@@ -1324,7 +1324,7 @@ function rtss_wp_get_shares() {
 		$response = wp_remote_get(
 			add_query_arg(
 				array(
-					'id'           => urlencode( get_permalink( $post_id ) ),
+					'id'           => rawurlencode( get_permalink( $post_id ) ),
 					'access_token' => $access_token,
 					'fields'       => 'engagement',
 				),

--- a/template/rtsocial-setting-form.php
+++ b/template/rtsocial-setting-form.php
@@ -310,6 +310,13 @@
 										</td>
 										<td>&nbsp;</td>
 									</tr>
+									<tr class="fb_row">
+										<th><?php esc_html_e( 'Facebook App Access Token', 'rtSocial' ); ?>:</th>
+										<td>
+											<input type="text" value="<?php echo esc_attr( $options['fb_access_token'] ); ?>" id="fb_access_token" name="rtsocial_plugin_options[fb_access_token]" />
+										</td>
+										<td>&nbsp;</td>
+									</tr>
 								</table>
 							</div>
 						</div>

--- a/template/rtsocial-setting-form.php
+++ b/template/rtsocial-setting-form.php
@@ -317,6 +317,14 @@
 										</td>
 										<td>&nbsp;</td>
 									</tr>
+									<tr>
+										<th>&nbsp;</th>
+										<td colspan="2">
+											<b>Format:</b> App ID|App Secret <br/>
+											<b>Example:</b> 3245678987646576|dfghjhg4564768jjgvjvbnnh9876 <br/>
+											Follow these <a href="https://github.com/rtCamp/rtsocial/wiki#how-to-get-facebook-access-token" target="_blank">guideline</a> to generate your access token.
+										</td>
+									</tr>
 								</table>
 							</div>
 						</div>


### PR DESCRIPTION
Fixes : [#141](https://github.com/rtCamp/rtMedia-Pro/issues/141) Only Facebook Part

Add setting to get URL share count from the
Facebook API

We are trying to fetch the URL engagement point with the
App ID and the App secret key, stored at the server end