### PR TITLE
GH : #96 Social sharing icons not visible on home page - Twenty Twenty-Two theme

### DIFF
--- a/source.php
+++ b/source.php
@@ -98,6 +98,8 @@ function rtsocial_get_errors() {
  */
 add_filter( 'the_content', 'rtsocial_counter' );
 add_filter( 'the_excerpt', 'rtsocial_counter' );
+// To show rtSocial buttons in Twenty-Twenty-Two Theme.
+add_filter( 'get_the_excerpt', 'rtsocial_counter' );
 
 /**
  * Dynamic Content.


### PR DESCRIPTION
## Fixing issue

- #96  

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x]  Lint and tests pass locally with my changes

## Changes details

- Fix the appearance of social buttons for the Twenty-Twenty-Two Theme. 