### PR TITLE
GH : #109 PHP notice related to fb_access_token is displayed in log after updating to latest version

### DIFF
--- a/template/rtsocial-setting-form.php
+++ b/template/rtsocial-setting-form.php
@@ -313,7 +313,7 @@
 									<tr class="fb_row">
 										<th><?php esc_html_e( 'Facebook App Access Token', 'rtSocial' ); ?>:</th>
 										<td>
-											<input type="text" value="<?php echo esc_attr( $options['fb_access_token'] ); ?>" id="fb_access_token" name="rtsocial_plugin_options[fb_access_token]" />
+										<input type="text" value="<?php echo ( ! empty( $options['fb_access_token'] ) ) ? esc_attr( $options['fb_access_token'] ) : ''; ?>" id="fb_access_token" name="rtsocial_plugin_options[fb_access_token]" />
 										</td>
 										<td>&nbsp;</td>
 									</tr>


### PR DESCRIPTION
## Fixing issue

- #109 

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x]  Lint and tests pass locally with my changes

## Changes details

- Add condition check for fb_access_token