### PR TITLE
Version update v2.2.4 [Develop]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # rtSocial #
 
-* **Contributors:** [rtcamp](http://profiles.wordpress.org/rtcamp), [rahul286](http://profiles.wordpress.org/rahul286), [faishal](http://profiles.wordpress.org/faishal), [rittesh.patel](http://profiles.wordpress.org/rittesh.patel), [sanketparmar](http://profiles.wordpress.org/sanketparmar), [pranalipatel](http://profiles.wordpress.org/pranalipatel), [UmeshSingla](http://profiles.wordpress.org/UmeshSingla), [rutwick](http://profiles.wordpress.org/rutwick), [saurabhshukla](http://profiles.wordpress.org/saurabhshukla), [HarishChaudhari](http://profiles.wordpress.org/HarishChaudhari), [5um17](http://profiles.wordpress.org/5um17), [JoshuaAbenazer](http://profiles.wordpress.org/JoshuaAbenazer), [paddyohanlon](http://profiles.wordpress.org/paddyohanlon), [chandrapatel](http://profiles.wordpress.org/chandrapatel), [1naveengiri](http://profiles.wordpress.org/1naveengiri), [bhargavbhandari90](http://profiles.wordpress.org/bhargavbhandari90), [vaishu.agola27](https://profiles.wordpress.org/vaishuagola27/), [pooja1210](https://profiles.wordpress.org/pooja1210/), [milindmore22](https://profiles.wordpress.org/milindmore22), [pavanpatil1](https://profiles.wordpress.org/pavanpatil1/), [devanshijoshi](https://profiles.wordpress.org/devanshijoshi/), [mukulsingh27](https://profiles.wordpress.org/mukulsingh27/)
+* **Contributors:** [rtcamp](http://profiles.wordpress.org/rtcamp), [rahul286](http://profiles.wordpress.org/rahul286), [faishal](http://profiles.wordpress.org/faishal), [rittesh.patel](http://profiles.wordpress.org/rittesh.patel), [sanketparmar](http://profiles.wordpress.org/sanketparmar), [pranalipatel](http://profiles.wordpress.org/pranalipatel), [UmeshSingla](http://profiles.wordpress.org/UmeshSingla), [rutwick](http://profiles.wordpress.org/rutwick), [saurabhshukla](http://profiles.wordpress.org/saurabhshukla), [HarishChaudhari](http://profiles.wordpress.org/HarishChaudhari), [5um17](http://profiles.wordpress.org/5um17), [JoshuaAbenazer](http://profiles.wordpress.org/JoshuaAbenazer), [paddyohanlon](http://profiles.wordpress.org/paddyohanlon), [chandrapatel](http://profiles.wordpress.org/chandrapatel), [1naveengiri](http://profiles.wordpress.org/1naveengiri), [bhargavbhandari90](http://profiles.wordpress.org/bhargavbhandari90), [vaishu.agola27](https://profiles.wordpress.org/vaishuagola27/), [pooja1210](https://profiles.wordpress.org/pooja1210/), [milindmore22](https://profiles.wordpress.org/milindmore22), [pavanpatil1](https://profiles.wordpress.org/pavanpatil1/), [devanshijoshi](https://profiles.wordpress.org/devanshijoshi/), [mukulsingh27](https://profiles.wordpress.org/mukulsingh27/), [akrocks](https://profiles.wordpress.org/akrocks/)
 
 * **License:** [GPL v2 or later]( http://www.gnu.org/licenses/gpl-2.0.html)
 
@@ -56,6 +56,16 @@ No. Right now you cannot.
 
 
 ## Changelog ##
+
+#### 2.2.4 ####
+
+- ENHANCEMENTS 
+  - Compatible with WordPress v6.4.2.
+  - Compatible with PHP v8.2.
+
+- FIXED
+
+  - Fixed phpcs issues.
 
 #### 2.2.3 ####
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === rtSocial ===
-Contributors: rtcamp, rahul286, faishal, rittesh.patel, sanketparmar, pranalipatel, UmeshSingla, rutwick, saurabhshukla, HarishChaudhari, 5um17, JoshuaAbenazer, paddyohanlon, chandrapatel, 1naveengiri, bhargavbhandari90, coderboy007, vaishu.agola27, pooja1210, milindmore22, pavanpatil1, devanshijoshi9, Mukulsingh27
+Contributors: rtcamp, rahul286, faishal, rittesh.patel, sanketparmar, pranalipatel, UmeshSingla, rutwick, saurabhshukla, HarishChaudhari, 5um17, JoshuaAbenazer, paddyohanlon, chandrapatel, 1naveengiri, bhargavbhandari90, coderboy007, vaishu.agola27, pooja1210, milindmore22, pavanpatil1, devanshijoshi9, Mukulsingh27, akrocks
 Tags: rtcamp, social, sharing, share, social links, twitter, facebook, pin it, pinterest, linkedin, linked in, linked in share, plus one button, social share, social sharing
 Requires at least: 3.0
-Tested up to: 6.1
-Stable tag: 2.2.3
+Tested up to: 6.4.2
+Stable tag: 2.2.4
 License: GPLv2 or later (of-course)
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate Link: http://rtcamp.com/donate/
@@ -58,6 +58,17 @@ No. Right now you cannot.
 
 
 == Changelog ==
+
+= 2.2.4 =
+
+* ENHANCEMENTS
+
+ * Compatible with WordPress v6.4.2.
+ * Compatible with PHP v8.2.
+
+* FIXED
+
+ * Fixed phpcs issues.
 
 = 2.2.3 =
 

--- a/source.php
+++ b/source.php
@@ -11,7 +11,7 @@
  * Author URI:  https://rtcamp.com/
  * Text Domain: rtSocial
  * Domain Path: /languages
- * Version:     2.2.3
+ * Version:     2.2.4
  * License:     GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: It is the lightest social sharing plugin, uses non-blocking Javascript and a single sprite to get rid of all the clutter that comes along with the sharing buttons.


### PR DESCRIPTION
# Version Update for the rtsocial Plugin :arrow_double_up: 

Current Version: 2.2.3
Updating Version: 2.2.4

Updates to enhancements and fixes have been added in the Version Update as listed below.

Following is the changelog :spiral_notepad: from the previous version

## ENHANCEMENTS
   
- Compatible with WordPress v6.4.2.
- Compatible with PHP v8.2.

## Fixed
 
- Fixed phpcs issues.



## Fixes/Covers
- https://github.com/rtCamp/rtsocial/issues/125