### PR TITLE
Fix: replace # with * for mandatory Active Buttons field

### DIFF
--- a/template/rtsocial-setting-form.php
+++ b/template/rtsocial-setting-form.php
@@ -180,7 +180,7 @@
 										</td>
 									</tr>
 									<tr>
-										<th scope="row"><?php esc_html_e( 'Active Buttons', 'rtSocial' ); ?> <sup>#</sup>:</th>
+										<th scope="row"><?php esc_html_e( 'Active Buttons', 'rtSocial' ); ?> <sup>*</sup>:</th>
 										<td>
 											<ul id="rtsocial-sorter-active" class="connectedSortable">
 												<?php


### PR DESCRIPTION
## Description  
Replaced the `#` symbol with `*` for the **Active Buttons** field label on the settings page to correctly indicate that it is a mandatory field.  

## Why  
- `#` was inconsistent with other required fields.  
- `*` is the standard convention for mandatory fields.  

## Related Issue  
Fixes rtCamp/rtsocial#112
